### PR TITLE
Improve SKILL's and system instructions for multi-provider LLM support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/spring-ai-skills/build.gradle
+++ b/spring-ai-skills/build.gradle
@@ -16,16 +16,20 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/snapshot' }
 }
 
 ext {
-    set('springAiVersion', "2.0.0-M1")
+    set('springAiVersion', "2.0.0-SNAPSHOT")
 }
 
 dependencies {
+    // implementation 'org.springframework.ai:spring-ai-starter-model-anthropic'
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai-sdk'
+    // implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
+
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-    implementation 'org.springaicommunity:spring-ai-agent-utils:0.3.0'
-    implementation 'org.springframework.ai:spring-ai-starter-model-anthropic'
+    implementation 'org.springaicommunity:spring-ai-agent-utils:0.4.1'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/spring-ai-skills/src/main/java/com/example/demo/ChatClientConfig.java
+++ b/spring-ai-skills/src/main/java/com/example/demo/ChatClientConfig.java
@@ -12,19 +12,17 @@ import org.springframework.core.io.Resource;
 @Configuration
 public class ChatClientConfig {
 
-  @Value("classpath:/.claude/skills")
-  Resource skillPath;
+	@Value("classpath:/.claude/skills")
+	Resource skillPath;
 
-  @Bean
-  ChatClient chatClient(ChatClient.Builder chatClientBuilder) {
-    return chatClientBuilder
-        .defaultTools(
-            ShellTools.builder().build())
-        .defaultToolCallbacks(SkillsTool.builder()
-            .addSkillsResource(skillPath)
-            .build())
-        .defaultAdvisors(ToolCallAdvisor.builder().build())
-        .build();
-  }
+	@Bean
+	ChatClient chatClient(ChatClient.Builder chatClientBuilder) {
+		return chatClientBuilder
+			.defaultSystem("IMPORTANT: Always use the available skills to assist the user in their requests. When available follow skills instructions exactly.")
+			.defaultTools(ShellTools.builder().build())
+			.defaultToolCallbacks(SkillsTool.builder().addSkillsResource(skillPath).build())
+			.defaultAdvisors(ToolCallAdvisor.builder().build(), MyLoggingAdvisor.builder().build())
+			.build();
+	}
 
 }

--- a/spring-ai-skills/src/main/java/com/example/demo/MyLoggingAdvisor.java
+++ b/spring-ai-skills/src/main/java/com/example/demo/MyLoggingAdvisor.java
@@ -1,0 +1,151 @@
+package com.example.demo;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.util.StringUtils;
+
+public class MyLoggingAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	public final boolean showSystemMessage;
+
+	public final boolean showAvailableTools;
+
+	private MyLoggingAdvisor(int order, boolean showSystemMessage, boolean showAvailableTools) {
+		this.order = order;
+		this.showSystemMessage = showSystemMessage;
+		this.showAvailableTools = showAvailableTools;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+
+		StringBuilder sb = new StringBuilder("\nUSER: ");
+
+		if (this.showSystemMessage && chatClientRequest.prompt().getSystemMessage() != null) {
+			sb.append("\n - SYSTEM: " + first(chatClientRequest.prompt().getSystemMessage().getText(), 60));
+		}
+
+		if (this.showAvailableTools) {
+			Object tools = "No Tools";
+
+			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+				tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
+			}
+
+			sb.append("\n - TOOLS: " + ModelOptionsUtils.toJsonString(tools));
+		}
+
+		Message lastMessage = chatClientRequest.prompt().getLastUserOrToolResponseMessage();
+
+		if (lastMessage.getMessageType() == MessageType.TOOL) {
+			ToolResponseMessage toolResponseMessage = (ToolResponseMessage) lastMessage;
+			for (var toolResponse : toolResponseMessage.getResponses()) {
+				var tr = toolResponse.name() + ": " + first(toolResponse.responseData(), 300);
+				sb.append("\n - TOOL-RESPONSE: " + tr);
+			}
+		}
+		else if (lastMessage.getMessageType() == MessageType.USER) {
+			if (StringUtils.hasText(lastMessage.getText())) {
+				sb.append("\n - TEXT: " + first(lastMessage.getText(), 300));
+			}
+		}
+
+		System.out.println(sb.toString());
+
+		return chatClientRequest;
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		StringBuilder sb = new StringBuilder("\nASSISTANT: ");
+
+		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResults() == null) {
+			sb.append(" No chat response ");
+			System.out.println(sb.toString());
+			return chatClientResponse;
+		}
+
+		for (var generation : chatClientResponse.chatResponse().getResults()) {
+			var message = generation.getOutput();
+			if (message.getToolCalls() != null) {
+				for (var toolCall : message.getToolCalls()) {
+					sb.append("\n - TOOL-CALL: ")
+						.append(toolCall.name())
+						.append(" (")
+						.append(toolCall.arguments())
+						.append(")");
+				}
+			}
+
+			if (message.getText() != null) {
+				if (StringUtils.hasText(message.getText())) {
+					sb.append("\n - TEXT: " + first(message.getText(), 200));
+				}
+			}
+		}
+
+		System.out.println(sb.toString());
+
+		return chatClientResponse;
+	}
+
+	private String first(String text, int n) {
+		if (text.length() <= n) {
+			return text;
+		}
+		return text.substring(0, n) + "...";
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private int order = 0;
+
+		private boolean showSystemMessage = true;
+
+		private boolean showAvailableTools = true;
+
+		private Builder() {
+		}
+		
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+		
+		public Builder showSystemMessage(boolean showSystemMessage) {
+			this.showSystemMessage = showSystemMessage;
+			return this;
+		}
+
+		public Builder showAvailableTools(boolean showAvailableTools) {
+			this.showAvailableTools = showAvailableTools;
+			return this;
+		}
+
+		public MyLoggingAdvisor build() {
+			MyLoggingAdvisor advisor = new MyLoggingAdvisor(this.order, this.showSystemMessage,
+					this.showAvailableTools);
+			return advisor;
+		}
+
+	}
+
+}

--- a/spring-ai-skills/src/main/resources/.claude/skills/joke/SKILL.md
+++ b/spring-ai-skills/src/main/resources/.claude/skills/joke/SKILL.md
@@ -3,6 +3,6 @@ name: joke
 description: Tells jokes
 ---
 
-# Joke
+# Joke Telling Instructions
 
-When telling a joke, run `uv run ./scripts/joker.py` to obtain a joke.
+When telling a joke, always run `uv run ./scripts/joker.py` to obtain a joke. Use absolute paths!

--- a/spring-ai-skills/src/main/resources/application.properties
+++ b/spring-ai-skills/src/main/resources/application.properties
@@ -1,3 +1,24 @@
 spring.application.name=skills-demo
-spring.ai.anthropic.chat.options.model=claude-haiku-4-5
+# spring.ai.anthropic.chat.options.model=claude-haiku-4-5
+# spring.ai.anthropic.api-key=${ANTHROPIC_API_KEY}
+s
+## Anthropic Claude SDK
 spring.ai.anthropic.api-key=${ANTHROPIC_API_KEY}
+spring.ai.anthropic.chat.options.model=claude-sonnet-4-5-20250929
+spring.ai.anthropic.chat.options.max-tokens=1000
+
+
+## OpenAI SDK
+spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
+spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai-sdk.chat.options.temperature=1.0
+
+## Google GenAI SDK
+spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}
+# spring.ai.google.genai.location=${GOOGLE_CLOUD_LOCATION}
+spring.ai.google.genai.location=global
+spring.ai.google.genai.chat.options.model=gemini-3-pro-preview
+
+
+## Agent Configuration
+agent.skills.dirs=classpath:/.claude/skills


### PR DESCRIPTION
- Upgrade Spring AI from 2.0.0-M1 to 2.0.0-SNAPSHOT
- Upgrade spring-ai-agent-utils from 0.3.0 to 0.4.1 - uses improved tools description
- Add configuraitons for Anthropic, OpenAI SDK and Google GenAI LLMs
- Add Spring snapshot repository for SNAPSHOT dependencies
- Add MyLoggingAdvisor for debugging chat request/response flow
- Configure ChatClient with default system prompt for skills usage
- Update application.properties with configs for Anthropic, OpenAI, and Google GenAI
- Improve joke skill instructions to use absolute paths